### PR TITLE
Add a bunch of locks around things to fix some races

### DIFF
--- a/client_conn.go
+++ b/client_conn.go
@@ -181,6 +181,7 @@ func (c *clientConn) OnPacket(r *parser.PacketDecoder) {
 		t := c.getCurrent()
 		u := c.getUpgrade()
 		newWriter := t.NextWriter
+		c.writerLocker.Lock()
 		if u != nil {
 			if w, _ := t.NextWriter(message.MessageText, parser.NOOP); w != nil {
 				w.Close()
@@ -191,6 +192,7 @@ func (c *clientConn) OnPacket(r *parser.PacketDecoder) {
 			io.Copy(w, r)
 			w.Close()
 		}
+		c.writerLocker.Unlock()
 		fallthrough
 	case parser.PONG:
 		c.pingChan <- true


### PR DESCRIPTION
Running with `go run -race` and a lot of connections, I encountered some races that were causing crashes/disconnects. These modifications should fix that. Note: I didn't analyze these very closely; maybe they could be more efficient, or maybe they are completely broken.

There are a few whitespace changes introduced by `go fmt`; sorry.
