### PR TITLE
Fixed two race conditions, added wss:// schema when using HTTPS

### DIFF
--- a/client.go
+++ b/client.go
@@ -91,7 +91,9 @@ func (client *Client) Emit(message string, args ...interface{}) (err error) {
 		if err != nil {
 			return err
 		}
+		client.eventsLock.Lock()
 		client.acks[id] = c
+		client.eventsLock.Unlock()
 		return nil
 	}
 	return client.send(args)
@@ -192,7 +194,9 @@ func (client *Client) onPacket(decoder *decoder, packet *packet) ([]interface{},
 }
 
 func (client *Client) onAck(id int, decoder *decoder, packet *packet) error {
+	client.eventsLock.RLock()
 	c, ok := client.acks[id]
+	client.eventsLock.RUnlock()
 	if !ok {
 		return nil
 	}

--- a/client.go
+++ b/client.go
@@ -110,6 +110,7 @@ func (client *Client) sendConnect() error {
 }
 
 func (client *Client) sendId(args []interface{}) (int, error) {
+	client.eventsLock.Lock()
 	packet := packet{
 		Type: _EVENT,
 		Id:   client.id,
@@ -120,6 +121,8 @@ func (client *Client) sendId(args []interface{}) (int, error) {
 	if client.id < 0 {
 		client.id = 0
 	}
+	client.eventsLock.Unlock()
+
 	encoder := newEncoder(client.conn)
 	err := encoder.Encode(packet)
 	if err != nil {

--- a/client_conn.go
+++ b/client_conn.go
@@ -343,7 +343,11 @@ func (c *clientConn) onOpen() error {
 			return InvalidError
 		}
 
-		c.request.URL.Scheme = "ws"
+		if c.request.URL.Scheme == "https" {
+			c.request.URL.Scheme = "wss"
+		} else {
+			c.request.URL.Scheme = "ws"
+		}
 		q.Set("sid", c.id)
 		q.Set("transport", "websocket")
 		c.request.URL.RawQuery = q.Encode()


### PR DESCRIPTION
The race conditions are found with go build -race. Using HTTPS and ws:// schema causes a "websocket: bad handshake" error.